### PR TITLE
Adding a builder and utility for creating an SSLContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ SocketClient socketclient = new SocketClient("localhost", 25566, SSLContext.getD
 socketclient.connect();
 ```
 
+To create an SSLContext, you can use the `SSLContextUtility` in conjunction with the `SSLContextConfig`. 
+
+The `SSLContextConfig` contains several defaults, so for a standard `.jks` file, you only need to fill in the location (classpath or filesystem) and password. 
+
+These defaults can be overwritten for different types of keystore/truststore, such as PKCS11.
+
+Below is an example of using the `SSLContextUtility` to construct an `SSLContext` from an `SSLContextConfig`:
+
+```java
+final SSLContextConfig config = SSLContextConfig.builder()
+        .keystoreLocation("keystore.jks") // This is on the classpath
+        .keystorePassword("changeit")
+        .truststoreLocation("/usr/local/truststore.jks") // This is on the filesystem
+        .truststorePassword("changeit")
+        .build();
+final SSLContext sslContext = SSLContextUtility.getInstance().getSslContext(config);
+```
+
 ## Installation
 If your project is using Maven or Gradle, check the tutorials below.
 

--- a/src/main/java/xyz/baddeveloper/lwsl/ssl/CustomKeyManager.java
+++ b/src/main/java/xyz/baddeveloper/lwsl/ssl/CustomKeyManager.java
@@ -1,0 +1,81 @@
+package xyz.baddeveloper.lwsl.ssl;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.X509ExtendedKeyManager;
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * This class is used if we have custom server or client aliases set, in order to select the correct alias.
+ */
+public class CustomKeyManager extends X509ExtendedKeyManager {
+
+    private final X509ExtendedKeyManager originalKeyManager;
+    private final String serverAlias;
+    private final String clientAlias;
+
+    public CustomKeyManager(X509ExtendedKeyManager originalKeyManager, String serverAlias, String clientAlias) {
+        this.originalKeyManager = originalKeyManager;
+        this.serverAlias = serverAlias;
+        this.clientAlias = clientAlias;
+    }
+
+    @Override
+    public String[] getClientAliases(String keyType, Principal[] principals) {
+        return originalKeyManager.getClientAliases(keyType, principals);
+    }
+
+    @Override
+    public String chooseClientAlias(String[] keyTypes, Principal[] principals, Socket socket) {
+        if (this.clientAlias != null) {
+            return this.clientAlias;
+        } else {
+            return originalKeyManager.chooseClientAlias(keyTypes, principals, socket);
+        }
+    }
+
+    @Override
+    public String[] getServerAliases(String keyType, Principal[] principals) {
+        return originalKeyManager.getServerAliases(keyType, principals);
+    }
+
+    @Override
+    public String chooseServerAlias(String keyType, Principal[] principals, Socket socket) {
+        if (this.serverAlias != null) {
+            return this.serverAlias;
+        } else {
+            return originalKeyManager.chooseServerAlias(keyType, principals, socket);
+        }
+    }
+
+    @Override
+    public X509Certificate[] getCertificateChain(String alias) {
+        return originalKeyManager.getCertificateChain(alias);
+    }
+
+    @Override
+    public PrivateKey getPrivateKey(String alias) {
+        return originalKeyManager.getPrivateKey(alias);
+    }
+
+    @Override
+    public String chooseEngineClientAlias(String[] keyType, Principal[] principals, SSLEngine sslEngine) {
+        if (this.clientAlias != null) {
+            return this.clientAlias;
+        } else {
+            return originalKeyManager.chooseEngineClientAlias(keyType, principals, sslEngine);
+        }
+    }
+
+    @Override
+    public String chooseEngineServerAlias(String keyType, Principal[] principals, SSLEngine sslEngine) {
+        if (this.serverAlias != null) {
+            return this.serverAlias;
+        } else {
+            return originalKeyManager.chooseEngineServerAlias(keyType, principals, sslEngine);
+        }
+    }
+
+}

--- a/src/main/java/xyz/baddeveloper/lwsl/ssl/SSLContextConfig.java
+++ b/src/main/java/xyz/baddeveloper/lwsl/ssl/SSLContextConfig.java
@@ -1,0 +1,331 @@
+package xyz.baddeveloper.lwsl.ssl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.security.KeyStore;
+
+public class SSLContextConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SSLContextConfig.class);
+    private static final String PASSWORD_MASK = "*****";
+
+    private String protocol;
+    private String keyManager;
+    private String trustManager;
+    private String keystoreType;
+    private String keystoreProvider;
+    private String keystoreLocation;
+    private String keystorePassword;
+    private String keystoreServerAlias;
+    private String keystoreClientAlias;
+    private String truststoreType;
+    private String truststoreProvider;
+    private String truststoreLocation;
+    private String truststorePassword;
+
+    private SSLContextConfig(Builder builder) {
+        this.protocol = builder.protocol;
+        this.keyManager = builder.keyManager;
+        this.trustManager = builder.trustManager;
+        this.keystoreType = builder.keystoreType;
+        this.keystoreProvider = builder.keystoreProvider;
+        this.keystoreLocation = builder.keystoreLocation;
+        this.keystorePassword = builder.keystorePassword;
+        this.keystoreServerAlias = builder.keystoreServerAlias;
+        this.keystoreClientAlias = builder.keystoreClientAlias;
+        this.truststoreType = builder.truststoreType;
+        this.truststoreProvider = builder.truststoreProvider;
+        this.truststoreLocation = builder.truststoreLocation;
+        this.truststorePassword = builder.truststorePassword;
+        validatePasswords();
+    }
+
+    private void validatePasswords() {
+        if (this.keystorePassword == null) {
+            LOGGER.warn("The keystore password was not set. You may not be able to open the keystore.");
+        }
+
+        if (this.truststorePassword == null) {
+            LOGGER.warn("The truststore password was not set. You may not be able to open the truststore.");
+        }
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getKeyManager() {
+        return keyManager;
+    }
+
+    public String getTrustManager() {
+        return trustManager;
+    }
+
+    public String getKeystoreType() {
+        return keystoreType;
+    }
+
+    public String getKeystoreProvider() {
+        return keystoreProvider;
+    }
+
+    public String getKeystoreLocation() {
+        return keystoreLocation;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getKeystoreServerAlias() {
+        return keystoreServerAlias;
+    }
+
+    public String getKeystoreClientAlias() {
+        return keystoreClientAlias;
+    }
+
+    public String getTruststoreType() {
+        return truststoreType;
+    }
+
+    public String getTruststoreProvider() {
+        return truststoreProvider;
+    }
+
+    public String getTruststoreLocation() {
+        return truststoreLocation;
+    }
+
+    public String getTruststorePassword() {
+        return truststorePassword;
+    }
+
+    @Override
+    public String toString() {
+        return "SSLContextConfig{" +
+                "protocol='" + protocol + '\'' +
+                ", keyManager='" + keyManager + '\'' +
+                ", trustManager='" + trustManager + '\'' +
+                ", keystoreType='" + keystoreType + '\'' +
+                ", keystoreProvider='" + keystoreProvider + '\'' +
+                ", keystoreLocation='" + keystoreLocation + '\'' +
+                ", keystorePassword='" + (keystorePassword == null ? null : PASSWORD_MASK) + '\'' +
+                ", keystoreServerAlias='" + keystoreServerAlias + '\'' +
+                ", keystoreClientAlias='" + keystoreClientAlias + '\'' +
+                ", truststoreType='" + truststoreType + '\'' +
+                ", truststoreProvider='" + truststoreProvider + '\'' +
+                ", truststoreLocation='" + truststoreLocation + '\'' +
+                ", truststorePassword='" + (truststorePassword == null ? null : PASSWORD_MASK) + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (this == o) {
+            return true;
+        }
+        if (!(o.getClass().equals(this.getClass()))) {
+            return false;
+        }
+
+        SSLContextConfig that = (SSLContextConfig) o;
+
+        if (protocol != null ? !protocol.equals(that.protocol) : that.protocol != null) {
+            return false;
+        }
+        if (keyManager != null ? !keyManager.equals(that.keyManager) : that.keyManager != null) {
+            return false;
+        }
+        if (trustManager != null ? !trustManager.equals(that.trustManager) : that.trustManager != null) {
+            return false;
+        }
+        if (keystoreType != null ? !keystoreType.equals(that.keystoreType) : that.keystoreType != null) {
+            return false;
+        }
+        if (keystoreProvider != null ? !keystoreProvider.equals(that.keystoreProvider) : that.keystoreProvider != null) {
+            return false;
+        }
+        if (keystoreLocation != null ? !keystoreLocation.equals(that.keystoreLocation) : that.keystoreLocation != null) {
+            return false;
+        }
+        if (keystorePassword != null ? !keystorePassword.equals(that.keystorePassword) : that.keystorePassword != null) {
+            return false;
+        }
+        if (keystoreServerAlias != null ? !keystoreServerAlias.equals(that.keystoreServerAlias) : that.keystoreServerAlias != null) {
+            return false;
+        }
+        if (keystoreClientAlias != null ? !keystoreClientAlias.equals(that.keystoreClientAlias) : that.keystoreClientAlias != null) {
+            return false;
+        }
+        if (truststoreType != null ? !truststoreType.equals(that.truststoreType) : that.truststoreType != null) {
+            return false;
+        }
+        if (truststoreProvider != null ? !truststoreProvider.equals(that.truststoreProvider) : that.truststoreProvider != null) {
+            return false;
+        }
+        if (truststoreLocation != null ? !truststoreLocation.equals(that.truststoreLocation) : that.truststoreLocation != null) {
+            return false;
+        }
+        return truststorePassword != null ? !truststorePassword.equals(that.truststorePassword) : that.truststorePassword != null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = protocol != null ? protocol.hashCode() : 0;
+        result = 31 * result + (keyManager != null ? keyManager.hashCode() : 0);
+        result = 31 * result + (trustManager != null ? trustManager.hashCode() : 0);
+        result = 31 * result + (keystoreType != null ? keystoreType.hashCode() : 0);
+        result = 31 * result + (keystoreProvider != null ? keystoreProvider.hashCode() : 0);
+        result = 31 * result + (keystoreLocation != null ? keystoreLocation.hashCode() : 0);
+        result = 31 * result + (keystorePassword != null ? keystorePassword.hashCode() : 0);
+        result = 31 * result + (keystoreServerAlias != null ? keystoreServerAlias.hashCode() : 0);
+        result = 31 * result + (keystoreClientAlias != null ? keystoreClientAlias.hashCode() : 0);
+        result = 31 * result + (truststoreType != null ? truststoreType.hashCode() : 0);
+        result = 31 * result + (truststoreProvider != null ? truststoreProvider.hashCode() : 0);
+        result = 31 * result + (truststoreLocation != null ? truststoreLocation.hashCode() : 0);
+        result = 31 * result + (truststorePassword != null ? truststorePassword.hashCode() : 0);
+        return result;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static Builder builder(SSLContextConfig config) {
+        return new Builder(config);
+    }
+
+    public static final class Builder {
+
+        private String protocol = "TLS";
+        private String keyManager = KeyManagerFactory.getDefaultAlgorithm();
+        private String trustManager = TrustManagerFactory.getDefaultAlgorithm();
+        private String keystoreType = KeyStore.getDefaultType();
+        private String keystoreProvider = "SUN";
+        private String keystoreLocation;
+        private String keystorePassword;
+        private String keystoreServerAlias;
+        private String keystoreClientAlias;
+        private String truststoreType = KeyStore.getDefaultType();
+        private String truststoreProvider = "SUN";
+        private String truststoreLocation;
+        private String truststorePassword;
+
+        private Builder() {
+        }
+
+        private Builder(SSLContextConfig sslConfig) {
+            this.protocol = sslConfig.protocol;
+            this.keyManager = sslConfig.keyManager;
+            this.trustManager = sslConfig.trustManager;
+            this.keystoreType = sslConfig.keystoreType;
+            this.keystoreProvider = sslConfig.keystoreProvider;
+            this.keystoreLocation = sslConfig.keystoreLocation;
+            this.keystorePassword = sslConfig.keystorePassword;
+            this.keystoreServerAlias = sslConfig.keystoreServerAlias;
+            this.keystoreClientAlias = sslConfig.keystoreClientAlias;
+            this.truststoreType = sslConfig.truststoreType;
+            this.truststoreProvider = sslConfig.truststoreProvider;
+            this.truststoreLocation = sslConfig.truststoreLocation;
+            this.truststorePassword = sslConfig.truststorePassword;
+        }
+
+        public Builder protocol(String protocol) {
+            this.protocol = protocol;
+            return this;
+        }
+
+        public Builder keyManager(String keyManager) {
+            this.keyManager = keyManager;
+            return this;
+        }
+
+        public Builder trustManager(String trustManager) {
+            this.trustManager = trustManager;
+            return this;
+        }
+
+        public Builder keystoreType(String keystoreType) {
+            this.keystoreType = keystoreType;
+            return this;
+        }
+
+        public Builder keystoreProvider(String keystoreProvider) {
+            this.keystoreProvider = keystoreProvider;
+            return this;
+        }
+
+        public Builder keystoreLocation(String keystoreLocation) {
+            this.keystoreLocation = keystoreLocation;
+            return this;
+        }
+
+        public Builder keystorePassword(String keystorePassword) {
+            this.keystorePassword = keystorePassword;
+            return this;
+        }
+
+        public Builder keystoreServerAlias(String keystoreServerAlias) {
+            this.keystoreServerAlias = keystoreServerAlias;
+            return this;
+        }
+
+        public Builder keystoreClientAlias(String keystoreClientAlias) {
+            this.keystoreClientAlias = keystoreClientAlias;
+            return this;
+        }
+
+        public Builder truststoreType(String truststoreType) {
+            this.truststoreType = truststoreType;
+            return this;
+        }
+
+        public Builder truststoreProvider(String truststoreProvider) {
+            this.truststoreProvider = truststoreProvider;
+            return this;
+        }
+
+        public Builder truststoreLocation(String truststoreLocation) {
+            this.truststoreLocation = truststoreLocation;
+            return this;
+        }
+
+        public Builder truststorePassword(String truststorePassword) {
+            this.truststorePassword = truststorePassword;
+            return this;
+        }
+
+        public SSLContextConfig build() {
+            LOGGER.debug("Building SSL Context Config: {}", this);
+            return new SSLContextConfig(this);
+        }
+
+        @Override
+        public String toString() {
+            return "Builder{" +
+                    "protocol='" + protocol + '\'' +
+                    ", keyManager='" + keyManager + '\'' +
+                    ", trustManager='" + trustManager + '\'' +
+                    ", keystoreType='" + keystoreType + '\'' +
+                    ", keystoreProvider='" + keystoreProvider + '\'' +
+                    ", keystoreLocation='" + keystoreLocation + '\'' +
+                    ", keystorePassword='" + (keystorePassword == null ? null : PASSWORD_MASK) + '\'' +
+                    ", keystoreServerAlias='" + keystoreServerAlias + '\'' +
+                    ", keystoreClientAlias='" + keystoreClientAlias + '\'' +
+                    ", truststoreType='" + truststoreType + '\'' +
+                    ", truststoreProvider='" + truststoreProvider + '\'' +
+                    ", truststoreLocation='" + truststoreLocation + '\'' +
+                    ", truststorePassword='" + (truststorePassword == null ? null : PASSWORD_MASK) + '\'' +
+                    '}';
+        }
+    }
+
+}

--- a/src/main/java/xyz/baddeveloper/lwsl/ssl/SSLContextUtility.java
+++ b/src/main/java/xyz/baddeveloper/lwsl/ssl/SSLContextUtility.java
@@ -1,0 +1,245 @@
+package xyz.baddeveloper.lwsl.ssl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509ExtendedKeyManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+
+public final class SSLContextUtility {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SSLContextUtility.class);
+
+    private static final SSLContextUtility INSTANCE = new SSLContextUtility();
+
+    private SSLContextUtility() {
+    }
+
+    public static SSLContextUtility getInstance() {
+        return INSTANCE;
+    }
+
+    public SSLContext getSslContext(SSLContextConfig config) {
+        try {
+            final SSLContext sslContext = SSLContext.getInstance(config.getProtocol());
+            final KeyManager[] keyManagers = getKeyManagers(config);
+            final TrustManager[] trustManagers = getTrustManagers(config);
+            if (keyManagers != null && trustManagers != null) {
+                sslContext.init(keyManagers, trustManagers, null);
+                return sslContext;
+            } else {
+                LOGGER.error("Failed to create an SSLContext using configuration: {}", config);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to create SSLContext using configuration: " + config, e);
+        }
+        return null;
+    }
+
+    private KeyManager[] getKeyManagers(SSLContextConfig config) {
+        final KeyManagerFactory kmf = initKeyStore(config);
+        KeyManager[] keyManagers = null;
+        if (kmf != null) {
+            keyManagers = getKeyManagers(kmf, config);
+        }
+        return keyManagers;
+    }
+
+    private KeyManager[] getKeyManagers(KeyManagerFactory kmf, SSLContextConfig config) {
+        final String serverAlias = config.getKeystoreServerAlias();
+        final String clientAlias = config.getKeystoreClientAlias();
+        if (serverAlias != null || clientAlias != null) {
+            return new KeyManager[]{new CustomKeyManager((X509ExtendedKeyManager) kmf.getKeyManagers()[0], serverAlias, clientAlias)};
+        } else {
+            return kmf.getKeyManagers();
+        }
+    }
+
+    private TrustManager[] getTrustManagers(SSLContextConfig config) {
+        final TrustManagerFactory tmf = initTrustStore(config);
+        TrustManager[] trustManagers = null;
+        if (tmf != null) {
+            trustManagers = tmf.getTrustManagers();
+        }
+        return trustManagers;
+    }
+
+    private KeyStore getStoreType(String storeType, String provider) {
+        try {
+            if (provider == null) {
+                LOGGER.warn("No provider was supplied for store type of '{}'.", storeType);
+                return KeyStore.getInstance(storeType);
+            } else {
+                return KeyStore.getInstance(storeType, provider);
+            }
+        } catch (KeyStoreException e) {
+            LOGGER.error("Failed to default store type of: " + storeType, e);
+        } catch (NoSuchProviderException e) {
+            LOGGER.error("Failed to find a provider of type: " + provider, e);
+        }
+        return null;
+    }
+
+    private KeyManagerFactory initKeyStore(SSLContextConfig config) {
+        final KeyStore keyStore = getStoreType(config.getKeystoreType(), config.getKeystoreProvider());
+        if (keyStore == null) {
+            return null;
+        }
+
+        try {
+            loadStore(keyStore, config.getKeystoreLocation(), config.getKeystorePassword());
+        } catch (IOException | NoSuchAlgorithmException | CertificateException e) {
+            LOGGER.error("Failed to load key store.", e);
+            return null;
+        }
+
+        LOGGER.info("Printing keystore details.");
+        printKeystore(keyStore);
+
+        KeyManagerFactory kmf = loadKeyManagerFactory(config);
+        if (kmf != null) {
+            try {
+                kmf.init(keyStore, config.getKeystorePassword().toCharArray());
+                return kmf;
+            } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
+                LOGGER.error("Failed to initialise key manager factory.", e);
+            }
+        }
+        return null;
+    }
+
+    private void printKeystore(KeyStore store) {
+        final Enumeration<String> aliases;
+        try {
+            aliases = store.aliases();
+            while (aliases.hasMoreElements()) {
+                final String nextElement = aliases.nextElement();
+                final String endingNewline = aliases.hasMoreElements() ? "" : "\n";
+                LOGGER.info("Found alias '{}'.{}", nextElement, endingNewline);
+            }
+        } catch (KeyStoreException e) {
+            LOGGER.error("Failed to print aliases from store.", e);
+        }
+    }
+
+    private KeyManagerFactory loadKeyManagerFactory(SSLContextConfig config) {
+        try {
+            return KeyManagerFactory.getInstance(config.getKeyManager());
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.error("Failed to load key manager factory: " + config.getKeyManager(), e);
+        }
+        return null;
+    }
+
+    private TrustManagerFactory initTrustStore(SSLContextConfig config) {
+        // If no trust store property is set, we will try to load system default truststore
+        if (!hasTrustStoreProperty(config)) {
+            LOGGER.info("No truststore properties set. Loading the default JVM trust manager.");
+            return loadDefaultJVMTrustManager();
+        } else {
+            final KeyStore trustStore = getStoreType(config.getTruststoreType(), config.getTruststoreProvider());
+            if (trustStore == null) {
+                return null;
+            }
+
+            try {
+                loadStore(trustStore, config.getTruststoreLocation(), config.getTruststorePassword());
+            } catch (IOException | NoSuchAlgorithmException | CertificateException e) {
+                LOGGER.error("Failed to load trust store.", e);
+                return null;
+            }
+
+            LOGGER.info("Printing truststore details.");
+            printKeystore(trustStore);
+
+            TrustManagerFactory tmf = loadTrustManagerFactory(config);
+            if (tmf != null) {
+                try {
+                    tmf.init(trustStore);
+                    return tmf;
+                } catch (KeyStoreException e) {
+                    LOGGER.error("Failed to initialise trust manager factory.", e);
+                }
+            }
+            return null;
+        }
+    }
+
+    private boolean hasTrustStoreProperty(SSLContextConfig config) {
+        return config.getTruststoreLocation() != null || config.getTruststorePassword() != null;
+    }
+
+    private TrustManagerFactory loadDefaultJVMTrustManager() {
+        try {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+
+            for (TrustManager trustManager : trustManagerFactory.getTrustManagers()) {
+                if (trustManager instanceof X509TrustManager) {
+                    X509TrustManager x509TrustManager = (X509TrustManager) trustManager;
+                    LOGGER.info("Printing truststore details.");
+                    printX509TrustManager(x509TrustManager);
+                }
+            }
+            return trustManagerFactory;
+        } catch (NoSuchAlgorithmException | KeyStoreException e) {
+            LOGGER.error("Failed to initialise trust manager factory.", e);
+        }
+
+        return null;
+    }
+
+    private void printX509TrustManager(X509TrustManager trustManager) {
+        final X509Certificate[] certs = trustManager.getAcceptedIssuers();
+        for (int i = 0; i < certs.length; i++) {
+            final String certDN = certs[i].getSubjectDN().getName();
+            final String endingNewline = (i < certs.length - 1) ? "" : "\n";
+            LOGGER.info("Found trusted cert '{}'.{}", certDN, endingNewline);
+        }
+    }
+
+    private TrustManagerFactory loadTrustManagerFactory(SSLContextConfig config) {
+        try {
+            return TrustManagerFactory.getInstance(config.getTrustManager());
+        } catch (NoSuchAlgorithmException e) {
+            LOGGER.error("Failed to load trust manager factory: " + config.getTrustManager(), e);
+        }
+        return null;
+    }
+
+    private void loadStore(KeyStore keyStore, String storeLocation, String password) throws IOException, NoSuchAlgorithmException, CertificateException {
+        keyStore.load(storeLocation == null ? null : getStoreInputStream(storeLocation), password.toCharArray());
+    }
+
+    public InputStream getStoreInputStream(String storeLocation) throws IOException {
+        // Look for the store file on the filesystem first, then on the classpath
+        File filesystemFile = new File(storeLocation);
+        if (filesystemFile.exists()) {
+            return new FileInputStream(filesystemFile);
+        }
+
+        final InputStream resourceAsStream = this.getClass().getClassLoader().getResourceAsStream(storeLocation);
+        if (resourceAsStream == null) {
+            throw new IOException("No file corresponding to '" + storeLocation + "' was found on the classpath or filesystem.");
+        }
+        return resourceAsStream;
+    }
+
+}

--- a/src/test/java/xyz/baddeveloper/lwsl/client/SocketClientTest.java
+++ b/src/test/java/xyz/baddeveloper/lwsl/client/SocketClientTest.java
@@ -6,13 +6,10 @@ import org.junit.Test;
 import xyz.baddeveloper.lwsl.client.exceptions.ConnectException;
 import xyz.baddeveloper.lwsl.packet.Packet;
 import xyz.baddeveloper.lwsl.server.SocketServer;
+import xyz.baddeveloper.lwsl.ssl.SSLContextConfig;
+import xyz.baddeveloper.lwsl.ssl.SSLContextUtility;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,8 +22,14 @@ public class SocketClientTest {
     private SSLContext sslContext;
 
     @Before
-    public void setUp() throws Exception {
-        sslContext = constructSslContext();
+    public void setUp() {
+        final SSLContextConfig config = SSLContextConfig.builder()
+                .keystoreLocation("keystore.jks")
+                .keystorePassword("changeit")
+                .truststoreLocation("truststore.jks")
+                .truststorePassword("changeit")
+                .build();
+        sslContext = SSLContextUtility.getInstance().getSslContext(config);
     }
 
 
@@ -109,31 +112,6 @@ public class SocketClientTest {
         final SocketClient socketClient = new SocketClient("localhost", 25567)
                 .addConnectEvent(socket -> fail("Should not have connected"));
         socketClient.connect();
-    }
-
-    private SSLContext constructSslContext() throws Exception {
-        // TODO : Provide a utility class for constructing SSLContext objects from parameters
-        final SSLContext sslContext = SSLContext.getInstance("TLS");
-        final KeyManager[] keyManagers = getKeyManagers();
-        final TrustManager[] trustManagers = getTrustManagers();
-        sslContext.init(keyManagers, trustManagers, null);
-        return sslContext;
-    }
-
-    private KeyManager[] getKeyManagers() throws Exception {
-        final KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        keyStore.load(this.getClass().getClassLoader().getResourceAsStream("keystore.jks"), "changeit".toCharArray());
-        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-        kmf.init(keyStore, "changeit".toCharArray());
-        return kmf.getKeyManagers();
-    }
-
-    private TrustManager[] getTrustManagers() throws Exception {
-        final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
-        trustStore.load(this.getClass().getClassLoader().getResourceAsStream("truststore.jks"), "changeit".toCharArray());
-        final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-        tmf.init(trustStore);
-        return tmf.getTrustManagers();
     }
 
 }


### PR DESCRIPTION
Adding a few new classes in order to streamline creating an SSLContext.

**SSLContextConfig:** This is just a simple builder for the required properties. It defaults most values to SUN/JKS, TLS, etc. (since most people will likely be loading standard .jks files from the filesystem or classpath, and using TLS).

**SSLContextUtility:** This takes the config and turns it into an SSLContext. It should handle most forms of configuration - such as SUN/JKS, PKCS11 (hardware certificates), no truststore (it'll load the default JVM truststore), etc.

**CustomKeyManager:** This is used when we have multiple certs in a keystore - we can set a particular server/client alias, and make sure that's used by the SSLContext.

That should cover most off the use cases around SSL/TLS in the library.